### PR TITLE
QOLOE-1021 Aligning 'no result' with the search widget

### DIFF
--- a/data-search-widget/data-search-widget.js
+++ b/data-search-widget/data-search-widget.js
@@ -893,7 +893,7 @@
               searchTool.template.paginate(results)
             } else {
               $('.results').append(
-                '<div id="no-results">' +
+                '<div id="no-results" class="col">' +
                 '<h3>No results found</h3>' +
                 '<p>' + errorMessage + '</p>' +
                 '</div>')


### PR DESCRIPTION
**Before:**
![image](https://github.com/user-attachments/assets/d14633b7-ce24-4669-8692-f3de1dc2b3e2)

**After:**
![image](https://github.com/user-attachments/assets/0f95fc46-1354-4a54-8025-62c303fd25c1)
