### PR TITLE
QOLOE-1022 Fix the issue with clear markers

### DIFF
--- a/data-search-widget/data-search-widget.js
+++ b/data-search-widget/data-search-widget.js
@@ -1416,6 +1416,11 @@
           map.removeLayer(layer);
       }
     });
+    map.eachLayer(function (layer) {
+      if (layer._layers) {
+        map.removeLayer(layer);
+      }
+    });
     // clear map layers
     globalClusters.clearLayers();
   }

--- a/data-search-widget/examples/ccms-business-search-leaflet.html
+++ b/data-search-widget/examples/ccms-business-search-leaflet.html
@@ -1,7 +1,11 @@
 ---
 layout: layout.njk
 ---
+<head>
+    <script src="/utils/helpers.js"></script>
+</head>
 
+<body>
 <div class="container">
     <div id="search-tool"></div>
 </div>
@@ -81,6 +85,20 @@ let category_options = [];
           'website',
           'discount',
         ],
+        locationSearch: {
+            enabled: true,
+            label: 'Suburb or postcode',
+            matchFields: {
+                suburb: 'outletSuburb',
+                postcode: 'outletPostcode'
+            },
+            distanceEnabled: true,
+            distanceRadius: {
+                label: 'Distance Around (km)',
+                default: 0,
+                options: ['', 5, 10, 15, 20, 50, 100, 200]
+            }
+        },
         filterFields: {
           parentCategory: {
             type: 'select',
@@ -180,3 +198,4 @@ let category_options = [];
     });
 })(jQuery);
 </script>
+</body>


### PR DESCRIPTION
This PR is to fix below bug:
To reproduce:

1. Load the page containing the search widget
3. Click clear
5. Search for:
      Keyword: fitness
      Postcode: 4053
      Distance: 10 Km

Search results are displayed correctly in the cards which is 5. However many extra markers are rendered on the map:
![image](https://github.com/user-attachments/assets/2fc733f5-f21b-43eb-81ef-73d36df9f855)
