### PR TITLE
QOLOE-1030 Removing was-validated swe class

### DIFF
--- a/data-search-widget/data-search-widget.js
+++ b/data-search-widget/data-search-widget.js
@@ -663,7 +663,6 @@
         var searchActions = {
           submit: function (event) {
             event.preventDefault()
-            $(this).closest('form').addClass('was-validated')
             if ($(':required', $(this)).length) {
               var valid = true
               $(':required', $(this)).each(function () {
@@ -899,8 +898,6 @@
                 '</div>')
               $('.page-summary, .pager').hide()
             }
-
-            $('#search-form .was-validated').removeClass('was-validated')
           }, // filterItems()
           orFilter: function (values, items) {
             var filteredItems = []


### PR DESCRIPTION
Removing `was-validated` class from the text fields as it is specific to SWE and also we are not actually doing any validation on these free text fields.