### PR TITLE
QOLOE-1046 Reset map bounds when there is no marker on the map

### DIFF
--- a/data-search-widget/data-search-widget.js
+++ b/data-search-widget/data-search-widget.js
@@ -917,6 +917,7 @@
             if (results.length) {
               searchTool.template.paginate(results)
             } else {
+              map.fitBounds(qldMApBounds);
               $('.results').append(
                 '<div id="no-results" class="col">' +
                 '<h3>No results found</h3>' +
@@ -1292,6 +1293,7 @@
   let lastFilteredResults;
   let includeMobileResults = true;
   let resetCalled = false;
+  let qldMApBounds;
 
   function addLeafletCSS(src) {
     $('<link>', {
@@ -1362,6 +1364,8 @@
     // Update markers when map is dragged or zoomed
     map.on('dragend', mapMoveCallback);
     map.on('zoomend', mapMoveCallback);
+
+    qldMApBounds = map.getBounds();
 
   }
   // End of: initMap
@@ -1445,6 +1449,8 @@
       lastFilteredResults = mapsData; // It has to come before fitBounds
       if (markerClusters.getBounds()._northEast && markerClusters.getBounds()._southWest) {
         map.fitBounds(markerClusters.getBounds(), { padding: [10, 10] });
+      } else {
+        map.fitBounds(qldMApBounds);
       }
     }
     //markerClusters.addTo(map);

--- a/data-search-widget/examples/ccms-business-search-leaflet.html
+++ b/data-search-widget/examples/ccms-business-search-leaflet.html
@@ -137,6 +137,14 @@ let category_options = [];
             if (set['Carer Scheme Flag'] === 'Yes') { set.cardType.push('Carers'); }
 
             set.cardType = set.cardType.join(',');
+
+            if (set['Mobile Business Flag'] == 'Yes') {
+              set.Latitude = '(blank)';
+              set.Longitude = '(blank)';
+              set['Outlet Address'] = '(blank)';
+              set['Outlet Suburb'] = '(blank)';
+              set['Outlet Postcode'] = '(blank)';
+            }
           })
           return data
         },


### PR DESCRIPTION
Update the map bounds to its initial staet when no marker is displayed on the map.
It covers two cases:

1. When all the returned results are mobile businesses
2. When no result is returned.

![image](https://github.com/user-attachments/assets/ed78e4cf-2c22-4fa1-a743-92344c5f3775)
