### PR TITLE
QOLOE-1153 Moving map controls to the left side of the map

### DIFF
--- a/data-search-widget/data-search-widget.js
+++ b/data-search-widget/data-search-widget.js
@@ -1338,14 +1338,14 @@
     else if (controlsPosition === "LEFT_BOTTOM") controlsPosition = "bottomleft";
     else if (controlsPosition === "LEFT_CENTER") controlsPosition = "bottomleft";
     else if (controlsPosition === "LEFT_TOP") controlsPosition = "topleft";
-    else if (!["bottomright", "topright", "bottomleft", "topleft"].includes(controlsPosition)) controlsPosition = "bottomright";
+    else if (!["bottomright", "topright", "bottomleft", "topleft"].includes(controlsPosition)) controlsPosition = "bottomleft";
 
     L.control.zoom({ position: controlsPosition }).addTo(map);
     L.control
         .scale({
             imperial: false,
             metric: true,
-            position: "topright",
+            position: "topleft",
         })
         .addTo(map);
 


### PR DESCRIPTION
Moving map controls to left side of the map so they don't interfere with search suggestion dropdown. This is the quickest solution to avoid changing any style the search suggestion.

<img width="1419" height="683" alt="image" src="https://github.com/user-attachments/assets/b4a46298-637f-4d04-8179-2d3c8f62b25f" />
