### PR TITLE
QOLOE-1167 Trim search keyword fields before applying filtering

### DIFF
--- a/data-search-widget/data-search-widget.js
+++ b/data-search-widget/data-search-widget.js
@@ -890,7 +890,7 @@
               }
               results = filteredItems.filter(function (item) {
                 var searchFields = $.map(config.keywordFields, function (field) {
-                  field = field.trim();
+                  field = searchTool.helpers.sanitise(field);
                   return item[field]
                 }).join(' ')
 
@@ -1061,6 +1061,15 @@
             .replace(/(?:^\w|[A-Z]|\b\w)/g, function (ltr, idx) { return idx === 0 ? ltr.toLowerCase() : ltr.toUpperCase() })
             .replace(/[\W_]+/g, '')
         }, // toCamelCase
+        // Removing greater than, less than, single and double quote characters and
+        // also leading and trailing space from the string
+        sanitise: function (str) {
+          return str.replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;').trim();
+        },
         toTitleCase: function (str) { return str.replace(/(?:^|\s)\w/g, function (match) { return match.toUpperCase() }) },
         dynamicSort: function (properties) {
           if (!properties) {

--- a/data-search-widget/data-search-widget.js
+++ b/data-search-widget/data-search-widget.js
@@ -890,6 +890,7 @@
               }
               results = filteredItems.filter(function (item) {
                 var searchFields = $.map(config.keywordFields, function (field) {
+                  field = field.trim();
                   return item[field]
                 }).join(' ')
 


### PR DESCRIPTION
Not trimming the search keyword before filtering causes returning null for the specified field.
Please see [QOLOE-1167](https://www.jira.services.qld.gov.au/browse/QOLOE-1167) for details.

[QOLOE-1167]: https://ssq-qol.atlassian.net/browse/QOLOE-1167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ