### PR TITLE
Adding map css classes as the widget config

### DIFF
--- a/data-search-widget/data-search-widget.js
+++ b/data-search-widget/data-search-widget.js
@@ -1117,7 +1117,7 @@
 
   function generateMapHtml(mapStyles) {
     var mapHtml = '<div id="search-widget-maps"';
-    mapHtml += leafletCSSClasses(mapStyles) ? 'class="' + leafletCSSClasses(config.mapStyles) + '"' : '';
+    mapHtml += leafletCSSClasses(mapStyles) ? 'class="' + leafletCSSClasses(mapStyles) + '"' : '';
     mapHtml += '></div>';
     return mapHtml;
   }

--- a/data-search-widget/data-search-widget.js
+++ b/data-search-widget/data-search-widget.js
@@ -1116,10 +1116,7 @@
   }
 
   function generateMapHtml(mapStyles) {
-    var mapHtml = '<div id="search-widget-maps"';
-    mapHtml += leafletCSSClasses(mapStyles) ? 'class="' + leafletCSSClasses(mapStyles) + '"' : '';
-    mapHtml += '></div>';
-    return mapHtml;
+    return `<div id="search-widget-maps" ${leafletCSSClasses(mapStyles) ? `class="${leafletCSSClasses(mapStyles)}"` : ''}></div>`;
   }
 
   function renderSearchWidget(searchTool, config, url, container) {

--- a/data-search-widget/data-search-widget.js
+++ b/data-search-widget/data-search-widget.js
@@ -1109,7 +1109,17 @@
   }
 
   function leafletCSSClasses(classList) {
-    return classList.join(" ");
+    if (classList.length > 0)
+      return classList.join(" ");
+    else
+      return null;
+  }
+
+  function generateMapHtml() {
+    var mapHtml = '<div id="search-widget-maps"';
+    mapHtml += leafletCSSClasses(config.mapStyles) ? 'class="' + leafletCSSClasses(config.mapStyles) + '"' : '';
+    mapHtml += '></div>';
+    return mapHtml;
   }
 
   function renderSearchWidget(searchTool, config, url, container) {
@@ -1168,9 +1178,7 @@
           data = searchTool.helpers.standardiseKeys(data)
 
           if (config.maps) {
-            var mapHtml = '<div id="search-widget-maps" class="' +
-                           leafletCSSClasses(config.mapStyles) +
-                           '"></div>';
+            var mapHtml = generateMapHtml(config.mapStyles);
             var mapDiv = $(mapHtml);
             var searchToolDiv = $('#search-tool');
             mapDiv.insertBefore(searchToolDiv);

--- a/data-search-widget/data-search-widget.js
+++ b/data-search-widget/data-search-widget.js
@@ -1108,6 +1108,10 @@
     }).appendTo('head');
   }
 
+  function leafletCSSClasses(classList) {
+    return classList.join(" ");
+  }
+
   function renderSearchWidget(searchTool, config, url, container) {
     // Get all data and merge into a single array.
     var returnedData = [];
@@ -1164,7 +1168,10 @@
           data = searchTool.helpers.standardiseKeys(data)
 
           if (config.maps) {
-            var mapDiv = $('<div id="search-widget-maps"></div>');
+            var mapHtml = '<div id="search-widget-maps" class="' +
+                           leafletCSSClasses(config.mapStyles) +
+                           '"></div>';
+            var mapDiv = $(mapHtml);
             var searchToolDiv = $('#search-tool');
             mapDiv.insertBefore(searchToolDiv);
             $('#search-widget-maps').css("height", "400px");

--- a/data-search-widget/data-search-widget.js
+++ b/data-search-widget/data-search-widget.js
@@ -1115,9 +1115,9 @@
       return null;
   }
 
-  function generateMapHtml() {
+  function generateMapHtml(mapStyles) {
     var mapHtml = '<div id="search-widget-maps"';
-    mapHtml += leafletCSSClasses(config.mapStyles) ? 'class="' + leafletCSSClasses(config.mapStyles) + '"' : '';
+    mapHtml += leafletCSSClasses(mapStyles) ? 'class="' + leafletCSSClasses(config.mapStyles) + '"' : '';
     mapHtml += '></div>';
     return mapHtml;
   }


### PR DESCRIPTION
Adding map css classes as the map div (class `leaflet-container`).
This would be useful to pass on QGDS specific classes like `rounded-4` to the map via CCT/Squiz.